### PR TITLE
Enabling Menu Template and Menu Item Template properties.

### DIFF
--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -195,6 +195,12 @@ angular.module('ui.grid')
       if ( $scope.grid.options.gridMenuShowHideColumns !== false ){
         menuItems = menuItems.concat( service.showHideColumns( $scope ) );
       }
+
+      if ( $scope.grid.options.menuItemTemplate ) {
+          menuItems.forEach(function (menuItem) {
+              menuItem.templateUrl = $scope.grid.options.menuItemTemplate;
+          });
+      }
       
       return menuItems;
     },

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -402,7 +402,18 @@ angular.module('ui.grid')
        * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
        */
       baseOptions.menuTemplate = baseOptions.menuTemplate || null;
-  
+    
+      /**
+       * @ngdoc string
+       * @name menuItemTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) Null by default. When provided, this setting uses a custom grid menu item
+       * template. Can be set to either the name of a template file 'menuItem_template.html', inline html
+       * <pre>'<li class="ui-grid-menu-item"><label>{{name}}</label></li>'</pre>, or the id
+       * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
+       */
+      baseOptions.menuItemTemplate = baseOptions.menuItemTemplate || null;
+   
       /**
        * @ngdoc string
        * @name rowTemplate

--- a/src/js/core/factories/GridOptions.js
+++ b/src/js/core/factories/GridOptions.js
@@ -391,6 +391,17 @@ angular.module('ui.grid')
        * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
        */
       baseOptions.footerTemplate = baseOptions.footerTemplate || null;
+   
+      /**
+       * @ngdoc string
+       * @name menuTemplate
+       * @propertyOf ui.grid.class:GridOptions
+       * @description (optional) Null by default. When provided, this setting uses a custom grid menu
+       * template. Can be set to either the name of a template file 'menu_template.html', inline html
+       * <pre>'<div class="ui-grid-menu" style="text-align: left">Custom Menu Header <ul><li ng-repeat="item in menuItems" ui-grid-menu-item></li></ul></div>'</pre>, or the id
+       * of a precompiled template (TBD how to use this).  Refer to the custom footer tutorial for more information.
+       */
+      baseOptions.menuTemplate = baseOptions.menuTemplate || null;
   
       /**
        * @ngdoc string

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -46,6 +46,7 @@ describe('GridOptions factory', function () {
         headerTemplate: null,
         footerTemplate: null,
         menuTemplate: null,
+        menuItemTemplate: null,
         rowTemplate: 'ui-grid/ui-grid-row',
         appScopeProvider: null
       });
@@ -87,7 +88,8 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
-        menuTemplate: 'testFooter',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : 'anotherRef'
@@ -126,7 +128,8 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
-        menuTemplate: 'testFooter',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : 'anotherRef'
@@ -169,7 +172,8 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
-        menuTemplate: 'testFooter',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption'
       };
@@ -207,7 +211,8 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
-        menuTemplate: 'testFooter',
+        menuTemplate: 'testMenu',
+        menuItemTemplate: 'testMenuItem',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : null

--- a/test/unit/core/factories/GridOptions.spec.js
+++ b/test/unit/core/factories/GridOptions.spec.js
@@ -45,6 +45,7 @@ describe('GridOptions factory', function () {
         rowEquality: jasmine.any(Function),
         headerTemplate: null,
         footerTemplate: null,
+        menuTemplate: null,
         rowTemplate: 'ui-grid/ui-grid-row',
         appScopeProvider: null
       });
@@ -86,6 +87,7 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuTemplate: 'testFooter',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : 'anotherRef'
@@ -124,6 +126,7 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuTemplate: 'testFooter',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : 'anotherRef'
@@ -166,6 +169,7 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuTemplate: 'testFooter',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption'
       };
@@ -203,6 +207,7 @@ describe('GridOptions factory', function () {
         rowEquality: testFunction,
         headerTemplate: 'testHeader',
         footerTemplate: 'testFooter',
+        menuTemplate: 'testFooter',
         rowTemplate: 'testRow',
         extraOption: 'testExtraOption',
         appScopeProvider : null


### PR DESCRIPTION
upstream pull request: https://github.com/angular-ui/ng-grid/pull/2816

ui-grid 3.0 took away the ability to specify a custom menu template. Adding it back in.