### PR TITLE
Fix for grid-menu being overlapped by elements later in the DOM

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -68,19 +68,18 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
            * angular-translate.js, it's not using it.  You need to test animations in an external application.
            */
           $scope.shown = true;
-
-          var parentPos = parent.getBoundingClientRect();
-          angular.element($document.context.body).append($elm);
-          var width = $document.context.body.clientWidth;
-          angular.element($elm).css({
-            "position":"absolute",
-            "top": parentPos.top + "px",
-            "right": parseInt(width - parentPos.right) + "px",
-            //217 is the default width of a ui-grid menu + IE scrollbar
-            "min-width": "217px"
-          });
-          angular.element($elm).addClass(".ui-grid");
-
+          if (parent.nodeType === 1){
+            var parentPos = parent.getBoundingClientRect();
+            angular.element($document.context.body).append($elm);
+            var width = $document.context.body.clientWidth;
+            angular.element($elm).css({
+              "position":"absolute",
+              "top": parentPos.top + "px",
+              "right": parseInt(width - parentPos.right) + "px",
+              "min-width": "217px"
+            });
+            angular.element($elm).addClass("ui-grid");
+          } 
           $timeout( function() {
             $scope.shownMid = true;
             $scope.$emit('menu-shown');
@@ -122,7 +121,10 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
           $timeout( function() {
             if ( !$scope.shownMid ){
               $scope.shown = false;
-              angular.element(parent).append($elm);
+              if (parent.nodeType === 1){
+                angular.element(parent).append($elm);
+                angular.element($elm).removeClass("ui-grid");
+              }
               $scope.$emit('menu-hidden');
             }
           }, 200);

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -69,6 +69,18 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
            */
           $scope.shown = true;
 
+          var parentPos = parent.getBoundingClientRect();
+          angular.element($document.context.body).append($elm);
+          var width = $document.context.body.clientWidth;
+          angular.element($elm).css({
+            "position":"absolute",
+            "top": parentPos.top + "px",
+            "right": parseInt(width - parentPos.right) + "px",
+            //217 is the default width of a ui-grid menu + IE scrollbar
+            "min-width": "217px"
+          });
+          angular.element($elm).addClass(".ui-grid");
+
           $timeout( function() {
             $scope.shownMid = true;
             $scope.$emit('menu-shown');
@@ -110,6 +122,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
           $timeout( function() {
             if ( !$scope.shownMid ){
               $scope.shown = false;
+              angular.element(parent).append($elm);
               $scope.$emit('menu-hidden');
             }
           }, 200);

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -75,8 +75,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
             angular.element($elm).css({
               "position":"absolute",
               "top": parentPos.top + "px",
-              "right": parseInt(width - parentPos.right) + "px",
-              "min-width": "217px"
+              "right": parseInt(width - parentPos.right) + "px"
             });
             angular.element($elm).addClass("ui-grid");
           } 

--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -8,7 +8,6 @@
   cursor: pointer;
   height: 31px;
   font-weight: normal;
-  position: relative;
 }
 
 .ui-grid-menu-button .ui-grid-icon-container {
@@ -30,6 +29,7 @@
   padding: 0 10px 20px 10px;
   cursor: pointer;
   box-sizing: border-box;
+  position:relative;
 }
 
 .ui-grid-menu .ui-grid-menu-inner {

--- a/src/less/menu.less
+++ b/src/less/menu.less
@@ -8,6 +8,7 @@
   cursor: pointer;
   height: 31px;
   font-weight: normal;
+  position: relative;
 }
 
 .ui-grid-menu-button .ui-grid-icon-container {


### PR DESCRIPTION
The grid-menu is removed from it's parent node, so long as it's parent is a proper node, and is appended to the body. The positioning is based on the parent, leaving it in the same place it would have been. This fix relies on using a set min-width of 217px, as we have out grid-menu's set for 200px and 17px is added to compensate for IE's scrollbars. 