### PR TITLE
Removing redundant line from move-columns

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -401,10 +401,6 @@
                 $document.off('touchend', upFn);
               };
 
-              if ($scope.col.colDef.enableColumnMoving) {
-                onDownEvents();
-              }
-
               var cloneElement = function () {
                 elmCloned = true;
 


### PR DESCRIPTION
The change removes a line that erroneously adds a second onMouseDown event that interferes with normal behavior. 