### PR TITLE
removed the notifyDataChange on toggle column visibility

### DIFF
--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -347,7 +347,6 @@ angular.module('ui.grid')
       gridCol.colDef.visible = !( gridCol.colDef.visible === true || gridCol.colDef.visible === undefined );
 
       gridCol.grid.refresh();
-      gridCol.grid.api.core.notifyDataChange( uiGridConstants.dataChange.COLUMN );
       gridCol.grid.api.core.raise.columnVisibilityChanged( gridCol );
     }
   };


### PR DESCRIPTION
As far as I understand it, the way ui-grid handles column menus and toggling column visibility and the way we setup our column menus have very little relation. Currently this line causes an issue in chrome where it changes the scroll position of our column menus as a side effect of a fix to make sure that the menu will rerender with all available options if the user opens it before the subscription full returns. 

