### PR TITLE
Adding a check for html direction in placing the grid-menu

### DIFF
--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -347,6 +347,7 @@ angular.module('ui.grid')
       gridCol.colDef.visible = !( gridCol.colDef.visible === true || gridCol.colDef.visible === undefined );
 
       gridCol.grid.refresh();
+      gridCol.grid.api.core.notifyDataChange( uiGridConstants.dataChange.COLUMN );
       gridCol.grid.api.core.raise.columnVisibilityChanged( gridCol );
     }
   };

--- a/src/js/core/directives/ui-grid-menu-button.js
+++ b/src/js/core/directives/ui-grid-menu-button.js
@@ -347,7 +347,6 @@ angular.module('ui.grid')
       gridCol.colDef.visible = !( gridCol.colDef.visible === true || gridCol.colDef.visible === undefined );
 
       gridCol.grid.refresh();
-      gridCol.grid.api.core.notifyDataChange( uiGridConstants.dataChange.COLUMN );
       gridCol.grid.api.core.raise.columnVisibilityChanged( gridCol );
     }
   };

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -102,9 +102,14 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
             var headerHeight = (grid && grid.headerHeight) ? grid.headerHeight : 0;
             angular.element($elm).css({
               "position":"absolute",
-              "top": parseInt(parentPos.top + headerHeight) + "px",
-              "right": parseInt(width - parentPos.right) + "px"
+              "top": parseInt(parentPos.top + headerHeight) + "px"
             });
+
+            if ($document.context.dir === "rtl"){
+              angular.element($elm).css({ "left": parseInt(parentPos.left) + "px" });
+            } else { 
+              angular.element($elm).css({ "right": parseInt(width - parentPos.right) + "px" });
+            }
             angular.element($elm).addClass("ui-grid");
           } 
           $timeout( function() {

--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -105,7 +105,7 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants, i18
               "top": parseInt(parentPos.top + headerHeight) + "px"
             });
 
-            if ($document.context.dir === "rtl"){
+            if (getComputedStyle(parent).direction === 'rtl'){
               angular.element($elm).css({ "left": parseInt(parentPos.left) + "px" });
             } else { 
               angular.element($elm).css({ "right": parseInt(width - parentPos.right) + "px" });


### PR DESCRIPTION
The menu was always placed relative to the right, causing it in RTL to appear on the wrong side of the menu, far away from the button. I just added a check for the direction of the page and to place the menu relative to the left in RTL situations.